### PR TITLE
Deprecated `URI.open via Kernel#open`

### DIFF
--- a/lib/money/bank/openexchangerates_bank.rb
+++ b/lib/money/bank/openexchangerates_bank.rb
@@ -266,7 +266,7 @@ class Money
       # Opens an url and reads the content
       # @return [String] unparsed JSON content
       def open_url
-        open(source_url).read
+        URI.open(source_url).read
       rescue OpenURI::HTTPError
         ''
       end

--- a/test/openexchangerates_bank_test.rb
+++ b/test/openexchangerates_bank_test.rb
@@ -30,12 +30,12 @@ describe Money::Bank::OpenexchangeratesBank do
     describe 'without rates' do
       it 'able to exchange a money to its own currency even without rates' do
         money = Money.new(0, 'USD')
-        subject.exchange_with(money, 'USD').must_equal money
+        _(subject.exchange_with(money, 'USD')).must_equal money
       end
 
       it "raise if it can't find an exchange rate" do
         money = Money.new(0, 'USD')
-        proc { subject.exchange_with(money, 'LTL') }
+        _(proc { subject.exchange_with(money, 'LTL') })
           .must_raise Money::Bank::UnknownRate
       end
     end
@@ -47,17 +47,17 @@ describe Money::Bank::OpenexchangeratesBank do
 
       it 'should be able to exchange money from USD to a known exchange rate' do
         money = Money.new(100, 'USD')
-        subject.exchange_with(money, 'BBD').must_equal Money.new(200, 'BBD')
+        _(subject.exchange_with(money, 'BBD')).must_equal Money.new(200, 'BBD')
       end
 
       it 'should be able to exchange money from a known exchange rate to USD' do
         money = Money.new(200, 'BBD')
-        subject.exchange_with(money, 'USD').must_equal Money.new(100, 'USD')
+        _(subject.exchange_with(money, 'USD')).must_equal Money.new(100, 'USD')
       end
 
       it "should raise if it can't find an exchange rate" do
         money = Money.new(0, 'USD')
-        proc { subject.exchange_with(money, 'LTL') }
+        _(proc { subject.exchange_with(money, 'LTL') })
           .must_raise Money::Bank::UnknownRate
       end
     end
@@ -87,21 +87,21 @@ describe Money::Bank::OpenexchangeratesBank do
       initial_size = File.read(temp_cache_path).size
       stub(subject).open_url { '' }
       subject.update_rates
-      File.read(temp_cache_path).size.must_equal initial_size
+      _(File.read(temp_cache_path).size).must_equal initial_size
     end
 
     it 'should not break an existing file if save returns json without rates' do
       initial_size = File.read(temp_cache_path).size
       stub(subject).open_url { '{ "error": "An error" }' }
       subject.update_rates
-      File.read(temp_cache_path).size.must_equal initial_size
+      _(File.read(temp_cache_path).size).must_equal initial_size
     end
 
     it 'should not break an existing file if save returns a invalid json' do
       initial_size = File.read(temp_cache_path).size
       stub(subject).open_url { '{ invalid_json: "An error" }' }
       subject.update_rates
-      File.read(temp_cache_path).size.must_equal initial_size
+      _(File.read(temp_cache_path).size).must_equal initial_size
     end
   end
 
@@ -114,7 +114,7 @@ describe Money::Bank::OpenexchangeratesBank do
 
     it 'should get from url' do
       subject.update_rates
-      subject.rates.wont_be_empty
+      _(subject.rates).wont_be_empty
     end
   end
 
@@ -126,7 +126,7 @@ describe Money::Bank::OpenexchangeratesBank do
     end
 
     it 'should raise an error if invalid path is given' do
-      proc { subject.update_rates }.must_raise Money::Bank::InvalidCache
+      _(proc { subject.update_rates }).must_raise Money::Bank::InvalidCache
     end
   end
 
@@ -146,16 +146,16 @@ describe Money::Bank::OpenexchangeratesBank do
     it 'should get from url normally' do
       stub(subject).source_url { data_path }
       subject.update_rates
-      subject.rates.wont_be_empty
+      _(subject.rates).wont_be_empty
     end
 
     it 'should save from url and get from cache' do
       stub(subject).source_url { data_path }
       subject.update_rates
-      @global_rates.wont_be_empty
+      _(@global_rates).wont_be_empty
       dont_allow(subject).source_url
       subject.update_rates
-      subject.rates.wont_be_empty
+      _(subject.rates).wont_be_empty
     end
   end
 
@@ -163,7 +163,7 @@ describe Money::Bank::OpenexchangeratesBank do
     it "should use the non-secure http url if secure_connection isn't set" do
       subject.secure_connection = nil
       subject.access_key = TEST_ACCESS_KEY
-      subject.source_url.must_equal "#{url}?base=#{source}&"\
+      _(subject.source_url).must_equal "#{url}?base=#{source}&"\
                                     "app_id=#{TEST_ACCESS_KEY}&"\
                                     'prettyprint=0'
     end
@@ -171,7 +171,7 @@ describe Money::Bank::OpenexchangeratesBank do
     it 'should use the non-secure http url if secure_connection is false' do
       subject.secure_connection = false
       subject.access_key = TEST_ACCESS_KEY
-      subject.source_url.must_equal "#{url}?base=#{source}&"\
+      _(subject.source_url).must_equal "#{url}?base=#{source}&"\
                                     "app_id=#{TEST_ACCESS_KEY}&"\
                                     'prettyprint=0'
     end
@@ -179,10 +179,10 @@ describe Money::Bank::OpenexchangeratesBank do
     it 'should use the secure https url if secure_connection is set to true' do
       subject.secure_connection = true
       subject.access_key = TEST_ACCESS_KEY
-      subject.source_url.must_equal "#{secure_url}?base=#{source}&"\
+      _(subject.source_url).must_equal "#{secure_url}?base=#{source}&"\
                                     "app_id=#{TEST_ACCESS_KEY}&"\
                                     'prettyprint=0'
-      subject.source_url.must_include 'https://'
+      _(subject.source_url).must_include 'https://'
     end
   end
 
@@ -197,7 +197,7 @@ describe Money::Bank::OpenexchangeratesBank do
     it 'should update itself with exchange rates from OpenexchangeratesBank' do
       subject.rates.keys.each do |currency|
         next unless Money::Currency.find(currency)
-        subject.get_rate('USD', currency).must_be :>, 0
+        _(subject.get_rate('USD', currency)).must_be :>, 0
       end
     end
 
@@ -217,7 +217,7 @@ describe Money::Bank::OpenexchangeratesBank do
         subject.add_rate('USD', 'WTF', 2)
         subject.add_rate('WTF', 'USD', 2)
         subject.exchange_with(5000.to_money('WTF'), 'USD').cents
-        subject.exchange_with(5000.to_money('WTF'), 'USD').cents.wont_equal 0
+        _(subject.exchange_with(5000.to_money('WTF'), 'USD').cents).wont_equal 0
       end
     end
   end
@@ -229,7 +229,7 @@ describe Money::Bank::OpenexchangeratesBank do
     end
 
     it 'should raise an error if no access key is set' do
-      proc { subject.update_rates }.must_raise Money::Bank::NoAccessKey
+      _(proc { subject.update_rates }).must_raise Money::Bank::NoAccessKey
     end
   end
 
@@ -253,11 +253,11 @@ describe Money::Bank::OpenexchangeratesBank do
     describe 'when the ttl has expired' do
       it 'should update the rates' do
         Timecop.freeze(subject.rates_timestamp + 1000) do
-          subject.get_rate('USD', 'EUR').must_equal @old_usd_eur_rate
+          _(subject.get_rate('USD', 'EUR')).must_equal @old_usd_eur_rate
         end
         Timecop.freeze(subject.rates_timestamp + 1001) do
-          subject.get_rate('USD', 'EUR').wont_equal @old_usd_eur_rate
-          subject.get_rate('USD', 'EUR').must_equal @new_usd_eur_rate
+          _(subject.get_rate('USD', 'EUR')).wont_equal @old_usd_eur_rate
+          _(subject.get_rate('USD', 'EUR')).must_equal @new_usd_eur_rate
         end
       end
 
@@ -265,7 +265,7 @@ describe Money::Bank::OpenexchangeratesBank do
         Timecop.freeze(subject.rates_timestamp + 1001) do
           exp_time = subject.rates_timestamp + 1000
           subject.expire_rates!
-          subject.rates_expiration.must_equal exp_time
+          _(subject.rates_expiration).must_equal exp_time
         end
       end
     end
@@ -275,7 +275,7 @@ describe Money::Bank::OpenexchangeratesBank do
         subject.update_rates
         exp_time = subject.rates_expiration
         subject.expire_rates!
-        subject.rates_expiration.must_equal exp_time
+        _(subject.rates_expiration).must_equal exp_time
       end
     end
   end
@@ -294,12 +294,12 @@ describe Money::Bank::OpenexchangeratesBank do
     it 'should return 1970-01-01 datetime if no rates' do
       stub(subject).open_url { '' }
       subject.update_rates
-      subject.rates_timestamp.must_equal Time.at(0)
+      _(subject.rates_timestamp).must_equal Time.at(0)
     end
 
     it 'should return a Time object' do
       subject.update_rates
-      subject.rates_timestamp.class.must_equal Time
+      _(subject.rates_timestamp.class).must_equal Time
     end
   end
 end


### PR DESCRIPTION
Fix #2 
- Deprected `URI.open via Kernel#open` warning fixed
- Minitest deprecate's warnings `must_equal, must_raise, wont_be_empty and wont_equal` fixed

<img width="1440" alt="Screen Shot 2021-04-06 at 5 13 06 PM" src="https://user-images.githubusercontent.com/6793843/113784758-92df5680-96fb-11eb-96bf-d0108c3dac08.png">
